### PR TITLE
Añadir remoto/presencial; Renta freelance.

### DIFF
--- a/pautas_oficiales.md
+++ b/pautas_oficiales.md
@@ -18,6 +18,8 @@ Para poder llevar un orden en este tema y que se pueda contar con la mayor canti
      Horario:
 
      Ubicación:
+     
+     Remoto/Presencial:
 
      Beneficios que se entregarán:
 
@@ -31,6 +33,10 @@ Para poder llevar un orden en este tema y que se pueda contar con la mayor canti
      Perfil Requerido:
 
      Fechas estimadas:
+     
+     Remoto/Presencial:
+     
+     Renta ofrecida por proyecto/por hora (aproximación):
 
      Descripcion del proyecto :
 


### PR DESCRIPTION
Añadir la posibilidad de que una oferta pueda ser clasificada como remota en caso de que se pueda.
Y requerir entregar valores para una oferta freelance, ya sea por proyecto o por hora.