### PR TITLE
Forzar especificar horarios correctamente

### DIFF
--- a/pautas_oficiales.md
+++ b/pautas_oficiales.md
@@ -85,6 +85,8 @@ Notas:
 
 > "Sueldo"/"Presupuesto" es obligatorio, ya sea un rango o un aproximado (freelance, contrato). Frases como "a convenir", "a evaluar", etc. sin un rango de dinero no son aceptables, debe haber un monto líquido.
 
+> Todo lo que especifique "Horario" debe incluir el detalle de la jornada. "Part time", "Full time" o similares no son aceptables. Debe especificarse correctamente los horarios, por ejemplo: Lu-Ju 09:00 a 18:00 hrs., Vi 09:00 a 15:00 hrs.
+
 > Para "cotizaciones" (de app, páginas web, apps webs, etc), se debe incluir un presupuesto.
 
 > "Datos de contacto" requiere que se especifique, obligatoriamente, el nombre de la persona. Además, es obligatorio una dirección de correo electrónico o teléfono (idealmente ambos, pero con uno es aceptable).


### PR DESCRIPTION
Evitar "part time", "full time" o similares. Especificar jornada como corresponde, ya que entrar a las 8 y salir a las 5 es distinto a entrar a las 10 y salir a las 7.